### PR TITLE
ensured path resolution on legacy Node supports local modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: node_js
 node_js:
 - 6
 - 8
+- 9
 
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y realpath
+
+script:
+- npm test

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -91,7 +91,7 @@ function resolveModulePath(filepath, rootDir) {
 	if(legacy) {
 		legacy = process.env.NODE_PATH; // cache previous value
 		rootDir = rootDir.replace(/\/{1,}$/, ""); // strip trailing slashes, to be safe
-		process.env.NODE_PATH = rootDir + "/node_modules";
+		process.env.NODE_PATH = `${rootDir}:${rootDir}/node_modules`;
 		require("module").Module._initPaths();
 	}
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1,6 +1,7 @@
 "use strict";
 
 let Manifest = require("./manifest");
+let resolveModulePath = require("./util/resolve");
 let createFile = require("./util/files");
 let { generateFingerprint, repr } = require("./util");
 let path = require("path");
@@ -84,23 +85,3 @@ module.exports = class AssetManager {
 		}
 	}
 };
-
-function resolveModulePath(filepath, rootDir) {
-	// older versions of Node do not support `require.resolve`'s `paths` option
-	let legacy = !require.resolve.paths;
-	if(legacy) {
-		legacy = process.env.NODE_PATH; // cache previous value
-		rootDir = rootDir.replace(/\/{1,}$/, ""); // strip trailing slashes, to be safe
-		process.env.NODE_PATH = `${rootDir}:${rootDir}/node_modules`;
-		require("module").Module._initPaths();
-	}
-
-	let res = require.resolve(filepath, { paths: [rootDir] });
-
-	if(legacy) { // restore previous environment
-		process.env.NODE_PATH = legacy;
-		require("module").Module._initPaths();
-	}
-
-	return res;
-}

--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -1,0 +1,29 @@
+"use strict";
+
+// older versions of Node do not support `require.resolve`'s `paths` option
+let legacy = !require.resolve.paths;
+if(!legacy) { // account for bug in Node v8.9.4 and below
+	let { version } = process;
+	if(version.substr(0, 3) === "v8.") {
+		let [minor, patch] = version.substr(3).split(".").map(i => parseInt(i, 10));
+		legacy = minor < 8 || patch <= 4;
+	}
+}
+
+module.exports = function resolveModulePath(filepath, rootDir) {
+	if(legacy) {
+		legacy = process.env.NODE_PATH; // cache previous value
+		rootDir = rootDir.replace(/\/{1,}$/, ""); // strip trailing slashes, to be safe
+		process.env.NODE_PATH = `${rootDir}:${rootDir}/node_modules`;
+		require("module").Module._initPaths();
+	}
+
+	let res = require.resolve(filepath, { paths: [rootDir] });
+
+	if(legacy) { // restore previous environment
+		process.env.NODE_PATH = legacy;
+		require("module").Module._initPaths();
+	}
+
+	return res;
+};

--- a/test/fixtures/dummy/index.js
+++ b/test/fixtures/dummy/index.js
@@ -1,0 +1,1 @@
+export default "SRC";

--- a/test/fixtures/dummy/src.js
+++ b/test/fixtures/dummy/src.js
@@ -1,0 +1,1 @@
+export default "SRC";

--- a/test/fixtures/node_modules/dummy/index.js
+++ b/test/fixtures/node_modules/dummy/index.js
@@ -1,0 +1,1 @@
+export default "PKG";

--- a/test/fixtures/node_modules/dummy/pkg.js
+++ b/test/fixtures/node_modules/dummy/pkg.js
@@ -1,0 +1,1 @@
+export default "PKG";

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -1,0 +1,39 @@
+/* global describe, before, after, it */
+"use strict";
+
+let AssetManager = require("../lib/manager");
+let path = require("path");
+let assert = require("assert");
+
+let assertSame = assert.strictEqual;
+
+describe("asset manager", _ => {
+	let cwd;
+
+	before(() => {
+		cwd = process.cwd();
+	});
+
+	after(() => {
+		process.chdir(cwd);
+	});
+
+	it("resolves file paths for local modules and third-party packages", () => {
+		let root = path.resolve(__dirname, "fixtures");
+		process.chdir(root);
+
+		let { resolvePath } = new AssetManager(root);
+
+		let filepath = resolvePath("dummy/src.js");
+		assertSame(path.relative(root, filepath), "dummy/src.js");
+
+		filepath = resolvePath("dummy/pkg.js");
+		assertSame(path.relative(root, filepath), "node_modules/dummy/pkg.js");
+
+		// local modules take precedence over third-party packages
+		["dummy", "dummy/index", "dummy/index.js"].forEach(module => {
+			let filepath = resolvePath(module);
+			assertSame(path.relative(root, filepath), "dummy/index.js");
+		});
+	});
+});


### PR DESCRIPTION
this addresses #20

note the commit message though - I'm not sure how to deal with that Node LTS issue; should we resort to parsing `process.version` in order to activate legacy mode for v8.9.4 and below? I'd hate to have failing tests on master until this is fixed _and_ rolled out

update: a38bc7889762c4903948c9ba791b4d194d95f151 - please review commits individually