### PR TITLE
added support for YAML configuration files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 let AssetManager = require("./manager");
 let { repr } = require("./util");
 let browserslist = require("browserslist");
+let fs = require("fs");
 let path = require("path");
 
 let DEFAULTS = {
@@ -17,7 +18,7 @@ module.exports = (rootDir, config = "faucet.config.js", // eslint-disable-next-l
 		{ watch, fingerprint, compact }) => {
 	let configPath = path.resolve(rootDir, config);
 	let configDir = path.dirname(configPath);
-	config = require(configPath);
+	config = loadConfig(configPath);
 
 	let assetManager = new AssetManager(configDir, {
 		manifestConfig: config.manifest,
@@ -35,7 +36,7 @@ module.exports = (rootDir, config = "faucet.config.js", // eslint-disable-next-l
 			return;
 		}
 
-		let plugin = load(plugins[type]);
+		let plugin = load(plugins[type], "plugin");
 		plugin(pluginConfig, assetManager, { watcher, browsers, compact });
 	});
 };
@@ -63,11 +64,30 @@ function makeWatcher(watchDirs, configDir, resolvePath) {
 	return watcher;
 }
 
-function load(pkg) {
+function loadConfig(filepath) {
+	try {
+		return require(filepath);
+	} catch(err) {
+		let yaml = load("js-yaml");
+		// XXX: changing extension automatically is hacky!?
+		let loadYAML = (filepath, extension) => {
+			filepath = filepath.replace(/\.js$/, extension);
+			let data = fs.readFileSync(filepath, "utf8");
+			return yaml.safeLoad(data);
+		};
+		try {
+			return loadYAML(filepath, ".yaml");
+		} catch(err) {
+			return loadYAML(filepath, ".yml");
+		}
+	}
+}
+
+function load(pkg, type = "package") {
 	try {
 		return require(pkg);
 	} catch(err) {
-		abort(`ERROR: missing plugin - please install ${repr(pkg)}`);
+		abort(`ERROR: missing ${type} - please install ${repr(pkg)}`);
 	}
 }
 


### PR DESCRIPTION
YAML can be less verbose/grawlixy than JavaScript, this allows users to choose their preferred format:

```javascript
module.exports = {
    sass: [{
        source: "./styles/index.scss",
        target: "./dist/bundle.css"
    }, {
        …
    }],
    js: [{
        source: "./src/index.ts",
        target: "./dist/bundle.js",
        format: "amd",
        externals: {
            jquery: "jQuery"
        },
        esnext: {
            exclude: ["underscore", "a11y-dialog"]
        }
    }, {
        …
    }]
};
```

```yaml
sass:
- source: ./styles/index.scss
  target: ./dist/bundle.css
- …

js:
- source: ./src/index.ts
  target: ./dist/bundle.js
  format: amd
  externals:
      jquery: jQuery
  esnext:
      exclude:
      - underscore
      - a11y-dialog
- …
```

I'm not entirely sure we wanna go there, but it seemed like a quick win and thus worth proposing - note the commit message though.