### PR TITLE
Manifest Helpers for easier manifest creation

### DIFF
--- a/lib/manifest-helper.js
+++ b/lib/manifest-helper.js
@@ -1,0 +1,16 @@
+let path = require("path");
+
+exports.manifest = (manifestPath, webRoot = ".", baseURL = "/") => {
+	return {
+		file: manifestPath,
+		value: f => `${baseURL}${path.relative(webRoot, f)}`
+	};
+};
+
+exports.briefManifest = (manifestPath, webRoot = ".", baseURL = "/") => {
+	return {
+		file: manifestPath,
+		key: (f, targetDir) => path.relative(targetDir, f),
+		value: f => `${baseURL}${path.relative(webRoot, f)}`
+	};
+};


### PR DESCRIPTION
This is a proposal to simplify manifest configuration. This is how it is used: In your faucet.config.js you require one of the manifest helpers. You then use it to configure your manifest. For example:

```
"use strict";
let { manifest } = require("faucet-pipeline/lib/manifest-helper");

module.exports = {
    sass: [{
        source: "./src/index.scss",
        target: "./dist/bundle.css"
    }],
    manifest: manifest("./dist/manifest.json", "./dist")
};
```

This will configure the manifest to be written to "dist/manifest.json", and use the "dist" directory as the "web root" (that's optional, if you don't provide it, it will just be the path relative to the config file). There's a third (optional) parameter to provide a baseURL. It defaults to "/".

There is a second manifest helper called "briefManifest" that works in the same way. The only difference is, that it will create "brief" keys, meaning that they are relative to the targets.