### PR TITLE
Better manifest config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,8 +52,8 @@ function makeWatcher(watchDirs, configDir, resolvePath) {
 	let watcher = niteOwl(watchDirs);
 	watcher.on("error", err => {
 		if(err.code === "ERR_TOO_MANY_FILES") {
-			abort("There are too many files being monitored, please use the " +
-					"`watchDirs` configuration setting:\n" +
+			abort("ERROR: there are too many files being monitored - please " +
+					"use the `watchDirs` configuration setting:\n" +
 					// eslint-disable-next-line max-len
 					"https://github.com/faucet-pipeline/faucet-pipeline#configuration-for-file-watching");
 		}

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -14,7 +14,7 @@ module.exports = class AssetManager {
 		if(manifestConfig) {
 			let manifestPath = this.resolvePath(manifestConfig.file,
 					{ enforceRelative: true });
-			this.manifest = new Manifest(manifestPath, manifestConfig);
+			this.manifest = new Manifest(manifestPath, manifestConfig, this);
 		}
 
 		// bind methods for convenience

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -11,15 +11,18 @@ module.exports = class AssetManager {
 		this.referenceDir = referenceDir;
 		this.fingerprint = fingerprint;
 		this.exitOnError = exitOnError;
-		if(manifestConfig) {
-			let manifestPath = this.resolvePath(manifestConfig.file,
-					{ enforceRelative: true });
-			this.manifest = new Manifest(manifestPath, manifestConfig, this);
-		}
 
 		// bind methods for convenience
 		this.writeFile = this.writeFile.bind(this);
 		this.resolvePath = this.resolvePath.bind(this);
+
+		if(manifestConfig) {
+			let { resolvePath } = this;
+			let manifestPath = resolvePath(manifestConfig.file, {
+				enforceRelative: true
+			});
+			this.manifest = new Manifest(manifestPath, manifestConfig, resolvePath);
+		}
 	}
 
 	writeFile(filepath, data, { targetDir, error } = {}) {

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -42,7 +42,7 @@ module.exports = class AssetManager {
 				}
 			}).
 			catch(err => { // eslint-disable-line handle-callback-err
-				abort("aborting");
+				abort(`aborting: ${err}`);
 			});
 	}
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -7,7 +7,7 @@ let { abort, repr } = require("./util");
 let retryTimings = [10, 50, 100, 250, 500, 1000];
 
 module.exports = class Manifest {
-	constructor(filepath, { key, value, baseURI, webRoot }, assetManager) {
+	constructor(filepath, { key, value, baseURI, webRoot }, resolvePath) {
 		this.filepath = filepath;
 		this._index = {};
 
@@ -24,9 +24,7 @@ module.exports = class Manifest {
 			this.valueTransform = value;
 		} else {
 			baseURI = baseURI || "/";
-			webRoot = assetManager.resolvePath(webRoot || "./", {
-				enforceRelative: true
-			});
+			webRoot = resolvePath(webRoot || "./", { enforceRelative: true });
 			this.valueTransform = filepath => baseURI + path.relative(webRoot, filepath);
 		}
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -19,7 +19,7 @@ module.exports = class Manifest {
 		}
 
 		if(value && (baseURI || webRoot)) {
-			abort("Either provide a value OR baseURI and/or webRoot");
+			abort("ERROR: `value` cannot be used with `baseURI` and/or `webRoot`");
 		} else if(value) {
 			this.valueTransform = value;
 		} else {

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -2,12 +2,12 @@
 
 let path = require("path");
 let createFile = require("./util/files");
-let { repr } = require("./util");
+let { abort, repr } = require("./util");
 
 let retryTimings = [10, 50, 100, 250, 500, 1000];
 
 module.exports = class Manifest {
-	constructor(filepath, { key, value }) {
+	constructor(filepath, { key, value, baseURI, webRoot }, assetManager) {
 		this.filepath = filepath;
 
 		if(key === "short") {
@@ -18,7 +18,18 @@ module.exports = class Manifest {
 			this.keyTransform = filepath => filepath;
 		}
 
-		this.valueTransform = value || (filepath => "/" + filepath);
+		if(value && (baseURI || webRoot)) {
+			abort("Either provide a value OR baseURI and/or webRoot");
+		} else if(value) {
+			this.valueTransform = value;
+		} else {
+			baseURI = baseURI || "/";
+			webRoot = assetManager.resolvePath(webRoot || "./", {
+				enforceRelative: true
+			});
+			this.valueTransform = filepath => baseURI + path.relative(webRoot, filepath);
+		}
+
 		this._index = {};
 
 		this._resolve = this._resolve.bind(this);

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,5 +1,6 @@
 "use strict";
 
+let path = require("path");
 let createFile = require("./util/files");
 let { repr } = require("./util");
 
@@ -8,7 +9,15 @@ let retryTimings = [10, 50, 100, 250, 500, 1000];
 module.exports = class Manifest {
 	constructor(filepath, { key, value }) {
 		this.filepath = filepath;
-		this.keyTransform = key || (filepath => filepath);
+
+		if(key === "short") {
+			this.keyTransform = (f, targetDir) => path.relative(targetDir, f);
+		} else if(key) {
+			this.keyTransform = key;
+		} else {
+			this.keyTransform = filepath => filepath;
+		}
+
 		this.valueTransform = value || (filepath => "/" + filepath);
 		this._index = {};
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -9,18 +9,18 @@ let retryTimings = [10, 50, 100, 250, 500, 1000];
 module.exports = class Manifest {
 	constructor(filepath, { key, value, baseURI, webRoot }, assetManager) {
 		this.filepath = filepath;
+		this._index = {};
 
 		if(key === "short") {
-			this.keyTransform = (f, targetDir) => path.relative(targetDir, f);
-		} else if(key) {
-			this.keyTransform = key;
+			this.keyTransform = (fp, targetDir) => path.relative(targetDir, fp);
 		} else {
-			this.keyTransform = filepath => filepath;
+			this.keyTransform = key || (filepath => filepath);
 		}
 
-		if(value && (baseURI || webRoot)) {
-			abort("ERROR: `value` cannot be used with `baseURI` and/or `webRoot`");
-		} else if(value) {
+		if(value) {
+			if(baseURI || webRoot) {
+				abort("ERROR: `value` cannot be used with `baseURI` and/or `webRoot`");
+			}
 			this.valueTransform = value;
 		} else {
 			baseURI = baseURI || "/";
@@ -29,8 +29,6 @@ module.exports = class Manifest {
 			});
 			this.valueTransform = filepath => baseURI + path.relative(webRoot, filepath);
 		}
-
-		this._index = {};
 
 		this._resolve = this._resolve.bind(this);
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-rc.1",
 	"description": "front-end asset pipeline",
 	"author": "FND",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
 		"nite-owl": "^3.3.1"
 	},
 	"devDependencies": {
-		"eslint-config-fnd": "^1.2.0",
+		"eslint-config-fnd": "^1.3.0",
 		"mocha": "^5.0.1",
 		"npm-run-all": "^4.1.2",
-		"release-util-fnd": "^1.0.7"
+		"release-util-fnd": "^1.1.0"
 	}
 }


### PR DESCRIPTION
As discussed, this allows two shortcuts for easier manifest configuration.

1. Provide "short" as the key, to get a short key (`(f, targetDir) => path.relative(targetDir, f)`)
2. Provide "webRoot" and/or "baseURI" instead of a value to build the most common value patterns.