### PR TITLE
simplified configuration discovery and CLI script

### DIFF
--- a/bin/faucet
+++ b/bin/faucet
@@ -1,52 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
-let start = require("../lib/index");
-let { repr } = require("../lib/util");
-let parseArgs = require("minimist");
+let faucet = require("../lib");
+let parseCLI = require("../lib/cli");
 
-let HELP = `
-Usage:
-  $ faucet [options]
-
-Options:
-  -h, --help
-    display this help message
-  -c, --config
-    configuration file (defaults to ${repr("faucet.config.js")})
-  -w, --watch
-    monitor the file system for changes to recompile automatically
-  --fingerprint
-    add unique hash to file names
-  --compact
-    reduce output size (e.g. via minification)
-`.trim();
-
-let argv = parseArgs(process.argv.slice(2), {
-	alias: {
-		c: "config",
-		w: "watch",
-		h: "help"
-	}
-});
-
-if(argv.help) {
-	console.log(HELP); // eslint-disable-line no-console
-	process.exit();
-}
-
-let options = ["watch", "fingerprint", "compact"].reduce((memo, option) => {
-	let value = argv[option];
-	if(value !== undefined) {
-		memo[option] = value;
-	}
-	return memo;
-}, {});
-
-if(options.watch && options.fingerprint) { // for convenience
-	console.error("you might consider disabling fingerprinting " +
-			`(${repr("--no-fingerprint")}) in watch mode to avoid littering ` +
-			"your file system with obsolete bundles");
-}
-
-start(process.cwd(), argv.config, options);
+let { rootDir, config, options } = parseCLI();
+faucet(rootDir, config, options);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 "use strict";
 
-let { abort, repr } = require("../util");
+let readConfig = require("./config");
+let { abort, repr } = require("./util");
 let parseArgs = require("minimist");
 
 let HELP = `
@@ -46,9 +47,7 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 				"mode to avoid littering your file system with obsolete bundles");
 	}
 
-	return {
-		rootDir: process.cwd(),
-		config: argv.config,
-		options
-	};
+	let rootDir = process.cwd();
+	let config = readConfig(rootDir, argv.config);
+	return { rootDir, config, options };
 };

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,54 @@
+"use strict";
+
+let { abort, repr } = require("../util");
+let parseArgs = require("minimist");
+
+let HELP = `
+Usage:
+  $ faucet [options]
+
+Options:
+  -h, --help
+    display this help message
+  -c, --config
+    configuration file (defaults to ${repr("faucet.config.js")})
+  -w, --watch
+    monitor the file system for changes to recompile automatically
+  --fingerprint
+    add unique hash to file names
+  --compact
+    reduce output size (e.g. via minification)
+`.trim();
+
+module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
+	argv = parseArgs(argv, {
+		alias: {
+			c: "config",
+			w: "watch",
+			h: "help"
+		}
+	});
+
+	if(argv.help) {
+		abort(help, 0);
+	}
+
+	let options = ["watch", "fingerprint", "compact"].reduce((memo, option) => {
+		let value = argv[option];
+		if(value !== undefined) {
+			memo[option] = value;
+		}
+		return memo;
+	}, {});
+
+	if(options.watch && options.fingerprint) { // for convenience
+		console.error("you might consider disabling fingerprinting in watch " +
+				"mode to avoid littering your file system with obsolete bundles");
+	}
+
+	return {
+		rootDir: process.cwd(),
+		config: argv.config,
+		options
+	};
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+let path = require("path");
+
+module.exports = function readConfig(rootDir, filepath = "faucet.config.js") {
+	let configPath = path.resolve(rootDir, filepath);
+	let config = require(configPath);
+	config._root = path.dirname(configPath);
+	return config;
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 let AssetManager = require("./manager");
 let { abort, repr } = require("./util");
 let browserslist = require("browserslist");
-let path = require("path");
 
 let DEFAULTS = {
 	plugins: { // maps config identifiers to corresponding import identifiers
@@ -13,11 +12,8 @@ let DEFAULTS = {
 	}
 };
 
-module.exports = (rootDir, config = "faucet.config.js", // eslint-disable-next-line indent
-		{ watch, fingerprint, compact }) => {
-	let configPath = path.resolve(rootDir, config);
-	let configDir = path.dirname(configPath);
-	config = require(configPath);
+module.exports = (rootDir, config, { watch, fingerprint, compact }) => {
+	let configDir = config._root;
 
 	let assetManager = new AssetManager(configDir, {
 		manifestConfig: config.manifest,

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,9 +3,9 @@
 let path = require("path");
 let crypto = require("crypto");
 
-exports.abort = msg => {
+exports.abort = (msg, code = 1) => {
 	console.error(msg);
-	process.exit(1);
+	process.exit(code);
 };
 
 exports.generateFingerprint = (filepath, data) => {


### PR DESCRIPTION
> * the CLI script has been reduced to a tiny wrapper around a proper
>   JavaScript module, which should simplify testing and reuse (e.g. for
>   creating alternative wrapper scripts)
> * the imperative API now expects a configuration object instead of a
>   file path, thus no longer conflating configuration discovery and
>   processing (note that this constitutes a breaking change)

a6ed821803fa4272bb6618e395c5b43d26a73905

This was prompted by ruminating on ways to simplify the [complate](https://github.com/complate) experience, where faucet is [being used](https://github.com/complate/complate-sample/blob/92895bb553cc5d4b18a71e1b9a85ee5d9cb85617/faucet.config.js) to compile JSX. The idea is to create a _simple_ wrapper script that auto-configures faucet:

```
$ complate ./views/index.jsx ./dist/views.js --watch
```

would end up invoking faucet-core with an additional bundle:

```javascript
let [source, target, ...args] = process.argv.slice(2);
let { rootDir, config, options } = parseCLI(args);

if(!config.js) {
    config.js = [];
}
config.js.push({
    source,
    target,
    moduleName: "render",
    jsx: { pragma: "createElement" }
});

options.fingerprint = false;
faucet(rootDir, config, options);
```

(we're extending/expecting an existing configuration file because we want to enable/encourage compiling other bundles within the same process - i.e. the goal is _not_ to hide faucet)