### PR TITLE
fixed reference directory for Browserslist discovery

### DIFF
--- a/bin/faucet
+++ b/bin/faucet
@@ -4,5 +4,5 @@
 let faucet = require("../lib");
 let parseCLI = require("../lib/cli");
 
-let { rootDir, config, options } = parseCLI();
-faucet(rootDir, config, options);
+let { referenceDir, config, options } = parseCLI();
+faucet(referenceDir, config, options);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,6 +48,6 @@ module.exports = function parseCLI(argv = process.argv.slice(2), help = HELP) {
 	}
 
 	let rootDir = process.cwd();
-	let config = readConfig(rootDir, argv.config);
-	return { rootDir, config, options };
+	let { referenceDir, config } = readConfig(rootDir, argv.config);
+	return { referenceDir, config, options };
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,8 @@ let path = require("path");
 
 module.exports = function readConfig(rootDir, filepath = "faucet.config.js") {
 	let configPath = path.resolve(rootDir, filepath);
-	let config = require(configPath);
-	config._root = path.dirname(configPath);
-	return config;
+	return {
+		referenceDir: path.dirname(configPath),
+		config: require(configPath)
+	};
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,17 +12,15 @@ let DEFAULTS = {
 	}
 };
 
-module.exports = (rootDir, config, { watch, fingerprint, compact }) => {
-	let configDir = config._root;
-
-	let assetManager = new AssetManager(configDir, {
+module.exports = (referenceDir, config, { watch, fingerprint, compact }) => {
+	let assetManager = new AssetManager(referenceDir, {
 		manifestConfig: config.manifest,
 		fingerprint,
 		exitOnError: !watch
 	});
-	let watcher = watch && makeWatcher(config.watchDirs, configDir,
+	let watcher = watch && makeWatcher(config.watchDirs, referenceDir,
 			assetManager.resolvePath);
-	let browsers = browserslist.findConfig(rootDir) || {};
+	let browsers = browserslist.findConfig(referenceDir) || {};
 
 	let plugins = Object.assign({}, DEFAULTS.plugins, config.plugins);
 	Object.keys(plugins).forEach(type => {
@@ -36,13 +34,13 @@ module.exports = (rootDir, config, { watch, fingerprint, compact }) => {
 	});
 };
 
-function makeWatcher(watchDirs, configDir, resolvePath) {
+function makeWatcher(watchDirs, referenceDir, resolvePath) {
 	let niteOwl = require("nite-owl");
 
 	/* eslint-disable indent */
 	watchDirs = watchDirs ?
 			watchDirs.map(dir => resolvePath(dir, { enforceRelative: true })) :
-			[configDir];
+			[referenceDir];
 	/* eslint-enable indent */
 
 	let watcher = niteOwl(watchDirs);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"lint": "eslint --cache *.js lib bin/* test && echo ✓"
 	},
 	"dependencies": {
-		"browserslist": "^3.2.3",
+		"browserslist": "^3.2.4",
 		"minimist": "^1.2.0",
 		"mkdirp": "^0.5.1",
 		"nite-owl": "^3.3.1"


### PR DESCRIPTION
from the commit message:

> the previous implementation erroneously distinguished between `rootDir`
> and `configDir` - when in fact we only want a single reference
> directory, based on the configuration file (which in turn is determined
> using the CLI's working directory)