### PR TITLE
replaced extract-sourcemap dependency with local script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,10 @@
 	"scripts": {
 		"test": "npm-run-all --parallel lint test:unit",
 		"test:unit": "mocha test/test_*.js",
-		"lint": "eslint --cache lib bin/* test && echo ✓"
+		"lint": "eslint --cache lib bin/* test test/bin/* && echo ✓"
 	},
 	"dependencies": {
 		"browserslist": "^4.0.0",
-		"extract-sourcemap": "^2.0.0",
 		"minimist": "^1.2.0",
 		"mkdirp": "^0.5.1",
 		"nite-owl": "^3.3.1"

--- a/test/bin/extract-sourcemap
+++ b/test/bin/extract-sourcemap
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+"use strict";
+
+let { readFileSync } = require("fs");
+
+let URL_PATTERN = /sourceMappingURL=data:(\S+)/;
+let MAP_PATTERN = /;base64,(\S+)$/;
+
+let [name, ...attributes] = process.argv.splice(2);
+if(!name) {
+	console.error("missing file name");
+	process.exit(1);
+}
+
+let source = readFileSync(name);
+let sourcemap = extractSourcemap(source, attributes);
+console.log(JSON.stringify(sourcemap)); // eslint-disable-line no-console
+
+function extractSourcemap(source, attributes) {
+	let url = firstMatchedGroup(URL_PATTERN, source);
+	let map = firstMatchedGroup(MAP_PATTERN, url);
+	if(!map) {
+		throw new Error("no source map found");
+	}
+	let sourceMapBuffer = Buffer.from(map, "base64");
+	let sourceMap = JSON.parse(sourceMapBuffer);
+	Object.keys(sourceMap).
+		filter(key => !attributes.includes(key)).
+		forEach(key => delete sourceMap[key]);
+	return sourceMap;
+}
+
+function firstMatchedGroup(regex, data) {
+	let matches = regex.exec(data);
+	if(!matches) {
+		return null;
+	}
+	return matches[1];
+}

--- a/test/cli_harness.sh
+++ b/test/cli_harness.sh
@@ -1,5 +1,9 @@
 set -euo pipefail
 
+bindir="$BASH_SOURCE"
+bindir=`dirname "$bindir"`
+bindir=`realpath "$bindir/bin"`
+
 # enters test directory
 function begin {
 	test_dir="${1:?}"
@@ -27,7 +31,8 @@ function assert_identical_sourcemap {
 	sed '\!sourceMappingURL!d' < "$actual.orig" > "$actual"
 	# limit source map to relevant properties (opaque, content-agnostic
 	# comparison is not an option due to system-specific file paths)
-	extract-sourcemap "$actual.orig" version names mappings sourcesContent > "$actual.map"
+	"$bindir/extract-sourcemap" "$actual.orig" version names mappings \
+			sourcesContent > "$actual.map"
 
 	assert_identical "$actual" "$expected_src"
 	assert_json "$actual.map" "$expected_map"


### PR DESCRIPTION
as discussed elsewhere, this avoids unintuitive dependency hoopla, as extract-sourcemap is only required for testing, but had to reside in `dependencies` rather than `devDependencies` anyway 🤯